### PR TITLE
Add bootstrap scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Assets/Plugins
 
 # vim
 *~
+
+log/
+resources

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+project=sushi
+
+echo "Attempting to build $project for OSX..."
+/Applications/Unity/Unity.app/Contents/MacOS/Unity \
+  -batchmode \
+  -nographics \
+  -projectPath $(pwd) \
+  -logFile $(pwd)/log/build.log \
+  -buildOSXUniversalPlayer $(pwd)/Build/osx/${project}.app \
+  -quit
+
+status=$?
+cat $(pwd)/log/build.log
+exit $status

--- a/Scripts/import-leap.sh
+++ b/Scripts/import-leap.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+package="LeapMotionCoreAsset_2_3_1.unitypackage"
+
+mkdir resources
+
+echo "Attempting to download and extract ${package}..."
+[ -f resources/${package}.zip ] || curl -o resources/${package}.zip -L https://github.com/leapmotion-examples/LeapMotionCoreAssets/releases/download/v2.3.1/${package}.zip
+unzip resources/${package}.zip -d resources
+
+echo "Attempting to import ${package}..."
+/Applications/Unity/Unity.app/Contents/MacOS/Unity \
+  -batchmode \
+  -nographics \
+  -projectPath $(pwd) \
+  -logFile $(pwd)/log/import-package.log \
+  -importPackage $(pwd)/resources/$package \
+  -quit
+
+status=$?
+cat $(pwd)/log/import-package.log
+exit $status


### PR DESCRIPTION
# What

Add bootstrap scripts to set up environment easily ~~and to build on Travis CI~~.
(It is difficult to build on Travis CI because it takes too long time to download Unity on Travis.)
# Progress
- ~~Install Unity~~
- [x] Import required packages (LeapMotionCoreAssets)
- [x] Build
- ~~Run these scripts on Travis CI~~
